### PR TITLE
Issue #SB-13339 fix : fixing es-lint package version to fix vulnarabi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     },
     "homepage": "https://github.com/ekstep/eslint-config-ekstep-content-plugin#readme",
     "devDependencies": {
-        "eslint": "^3.19.0"
+        "eslint": "^4.18.2"
     },
     "peerDependencies": {
-        "eslint": ">=3.19.0"
+        "eslint": ">=4.18.2"
     }
 }


### PR DESCRIPTION
https://project-sunbird.atlassian.net/browse/SB-13339

**ekstep-content-plugin-dev-common**
https://github.com/ekstep/ekstep-content-plugin-dev-common having as a dependency

```
"eslint-config-ekstep-content-plugin": "https://github.com/ekstep/eslint-config-ekstep-content-plugin.git"
```
Which has `eslint` version below `4.18.2` which creates security vulnarability

![image](https://user-images.githubusercontent.com/30499098/60786115-e9101600-a172-11e9-987e-4e82688c8ad3.png)
